### PR TITLE
# 68 - DB 칼럼을 DATETIME으로 변경

### DIFF
--- a/src/main/java/arile/toy/stock_service/domain/AuditingFields.java
+++ b/src/main/java/arile/toy/stock_service/domain/AuditingFields.java
@@ -23,7 +23,7 @@ public abstract class AuditingFields {
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) // 표준 date로 변경 (ISO)
     @CreatedDate // 자동으로 setting
-    @Column(nullable = false, updatable = false) // 생성과 관련된 정보는 update 되어서는 안된다.
+    @Column(nullable = false, updatable = false, columnDefinition = "DATETIME") // 생성과 관련된 정보는 update 되어서는 안된다.
     protected ZonedDateTime createdAt; // protected : 자식 class가 참조할 수 있도록 private(x)
 
     @CreatedBy
@@ -33,7 +33,7 @@ public abstract class AuditingFields {
     @Setter
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "DATETIME")
     protected ZonedDateTime modifiedAt;
 
     @Setter

--- a/src/main/java/arile/toy/stock_service/domain/GithubUserInfo.java
+++ b/src/main/java/arile/toy/stock_service/domain/GithubUserInfo.java
@@ -30,7 +30,7 @@ public class GithubUserInfo {
     @Column
     private String email;
 
-    @Column
+    @Column(columnDefinition = "DATETIME")
     private ZonedDateTime lastLoginAt;
 
     @Column

--- a/src/main/java/arile/toy/stock_service/domain/Reply.java
+++ b/src/main/java/arile/toy/stock_service/domain/Reply.java
@@ -25,11 +25,11 @@ public class Reply {
     private String body;
 
     @Setter
-    @Column
+    @Column(columnDefinition = "DATETIME")
     private ZonedDateTime createdAt;
 
     @Setter
-    @Column
+    @Column(columnDefinition = "DATETIME")
     private ZonedDateTime modifiedAt;
 
     @Setter

--- a/src/main/java/arile/toy/stock_service/domain/post/Post.java
+++ b/src/main/java/arile/toy/stock_service/domain/post/Post.java
@@ -48,11 +48,11 @@ public class Post {
     private Long dislikesCount = 0L;
 
     @Setter
-    @Column
+    @Column(columnDefinition = "DATETIME")
     private ZonedDateTime createdAt;
 
     @Setter
-    @Column
+    @Column(columnDefinition = "DATETIME")
     private ZonedDateTime modifiedAt;
 
     @Setter


### PR DESCRIPTION
Heroku 환경에서도 한국 시간 그대로 DB에 들어가게 함.