### PR TITLE
Caching 기법 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/arile/toy/stock_service/config/CacheConfig.java
+++ b/src/main/java/arile/toy/stock_service/config/CacheConfig.java
@@ -1,0 +1,9 @@
+package arile.toy.stock_service.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+}

--- a/src/main/java/arile/toy/stock_service/repository/StaticStockInfoRepository.java
+++ b/src/main/java/arile/toy/stock_service/repository/StaticStockInfoRepository.java
@@ -1,10 +1,12 @@
 package arile.toy.stock_service.repository;
 
 import arile.toy.stock_service.domain.StaticStockInfo;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface StaticStockInfoRepository extends JpaRepository<StaticStockInfo, Long> {
+    @Cacheable("stockNames")
     Optional<StaticStockInfo> findByStockName(String stockName);
 }

--- a/src/test/java/arile/toy/stock_service/controller/ChatControllerTest.java
+++ b/src/test/java/arile/toy/stock_service/controller/ChatControllerTest.java
@@ -3,12 +3,7 @@ package arile.toy.stock_service.controller;
 import arile.toy.stock_service.config.SecurityConfig;
 import arile.toy.stock_service.dto.ChatroomDto;
 import arile.toy.stock_service.dto.ChatroomWithCurrentStockDto;
-import arile.toy.stock_service.dto.GithubUserInfoDto;
-import arile.toy.stock_service.dto.InterestGroupWithCurrentInfoDto;
 import arile.toy.stock_service.dto.request.ChatroomRequest;
-import arile.toy.stock_service.dto.request.InterestGroupRequest;
-import arile.toy.stock_service.dto.request.InterestStockRequest;
-import arile.toy.stock_service.dto.response.ChatroomResponse;
 import arile.toy.stock_service.dto.security.GithubUser;
 import arile.toy.stock_service.service.ChatService;
 import arile.toy.stock_service.service.GithubOAuth2UserService;
@@ -24,12 +19,8 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Set;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.BDDMockito.then;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;

--- a/src/test/java/arile/toy/stock_service/controller/PostReplyControllerTest.java
+++ b/src/test/java/arile/toy/stock_service/controller/PostReplyControllerTest.java
@@ -4,7 +4,6 @@ import arile.toy.stock_service.config.SecurityConfig;
 import arile.toy.stock_service.dto.PostDto;
 import arile.toy.stock_service.dto.request.PostRequest;
 import arile.toy.stock_service.dto.request.ReplyRequest;
-import arile.toy.stock_service.dto.response.PostResponse;
 import arile.toy.stock_service.dto.security.GithubUser;
 import arile.toy.stock_service.service.GithubOAuth2UserService;
 import arile.toy.stock_service.service.PostService;

--- a/src/test/java/arile/toy/stock_service/service/ChatServiceTest.java
+++ b/src/test/java/arile/toy/stock_service/service/ChatServiceTest.java
@@ -1,8 +1,13 @@
 package arile.toy.stock_service.service;
 
 
-import arile.toy.stock_service.domain.*;
-import arile.toy.stock_service.dto.*;
+import arile.toy.stock_service.domain.Chatroom;
+import arile.toy.stock_service.domain.GithubUserChatroomMapping;
+import arile.toy.stock_service.domain.GithubUserInfo;
+import arile.toy.stock_service.domain.Message;
+import arile.toy.stock_service.dto.ChatroomDto;
+import arile.toy.stock_service.dto.ChatroomWithCurrentStockDto;
+import arile.toy.stock_service.dto.CurrentStockInfoDto;
 import arile.toy.stock_service.repository.GithubUserInfoRepository;
 import arile.toy.stock_service.repository.chats.ChatroomRepository;
 import arile.toy.stock_service.repository.chats.GithubUserChatroomMappingRepository;

--- a/src/test/java/arile/toy/stock_service/service/PostServiceTest.java
+++ b/src/test/java/arile/toy/stock_service/service/PostServiceTest.java
@@ -6,7 +6,6 @@ import arile.toy.stock_service.domain.Like;
 import arile.toy.stock_service.domain.post.Post;
 import arile.toy.stock_service.dto.PostDto;
 import arile.toy.stock_service.dto.SimplePostDto;
-import arile.toy.stock_service.dto.response.PostResponse;
 import arile.toy.stock_service.exception.post.PostNotFoundException;
 import arile.toy.stock_service.repository.DislikeRepository;
 import arile.toy.stock_service.repository.GithubUserInfoRepository;


### PR DESCRIPTION
같은 종목 관련 정보를 매번 query를 날려 DB에서 가져오는 것은 비효율적임.
종목 정보를 가져오는 페이지마다 이 query가 발생하여 다른 페이지에 비해 훨씬 느리다는 것을 확인함. (약 1.3s)
따라서, business logic에서 변경할 여지가 없는 정적인 종목 정보는 메모리의 cache를 활용하여 데이터를 가져오도록 함.
현재 heroku에서는 단일 dyno만 사용 중이므로, redis와 같은 외부 cache까지는 필요 없다고 판단함. 이후 필요성이 생기면 redis 사용할 예정,
