### PR TITLE
FK index

### DIFF
--- a/src/main/java/arile/toy/stock_service/domain/chat/Chatroom.java
+++ b/src/main/java/arile/toy/stock_service/domain/chat/Chatroom.java
@@ -13,7 +13,13 @@ import java.util.Set;
 
 @Getter
 @ToString
-@Table(name = "chatrooms")
+@Table(
+        name = "chatrooms",
+        indexes = {
+                @Index(name = "idx_chatrooms_stock_name", columnList = "stock_name"),
+                @Index(name = "idx_chatrooms_unchangeable_id", columnList = "unchangeable_id")
+        }
+)
 @Entity
 public class Chatroom {
 

--- a/src/main/java/arile/toy/stock_service/domain/chat/GithubUserChatroomMapping.java
+++ b/src/main/java/arile/toy/stock_service/domain/chat/GithubUserChatroomMapping.java
@@ -11,7 +11,13 @@ import java.util.Objects;
 
 @Getter
 @ToString
-@Table(name = "github_user_chatroom_mappings")
+@Table(
+        name = "github_user_chatroom_mappings",
+        indexes = {
+                @Index(name = "idx_gucm_unchangeable_id", columnList = "unchangeable_id"),
+                @Index(name = "idx_gucm_chatroom_id", columnList = "chatroom_id")
+        }
+)
 @Entity
 public class GithubUserChatroomMapping {
 

--- a/src/main/java/arile/toy/stock_service/domain/chat/Message.java
+++ b/src/main/java/arile/toy/stock_service/domain/chat/Message.java
@@ -11,7 +11,13 @@ import java.util.Objects;
 
 @Getter
 @ToString
-@Table(name = "messages")
+@Table(
+        name = "messages",
+        indexes = {
+                @Index(name = "idx_messages_unchangeable_id", columnList = "unchangeable_id"),
+                @Index(name = "idx_messages_chatroom_id", columnList = "chatroom_id")
+        }
+)
 @Entity
 public class Message {
 

--- a/src/main/java/arile/toy/stock_service/domain/interest/InterestGroup.java
+++ b/src/main/java/arile/toy/stock_service/domain/interest/InterestGroup.java
@@ -13,7 +13,12 @@ import java.util.Set;
 
 @Getter
 @ToString(callSuper = true)
-@Table(name = "interest_groups")
+@Table(
+        name = "interest_groups",
+        indexes = {
+                @Index(name = "idx_interest_groups_unchangeable_id", columnList = "unchangeable_id")
+        }
+)
 @Entity
 public class InterestGroup extends AuditingFields {
 

--- a/src/main/java/arile/toy/stock_service/domain/interest/InterestStock.java
+++ b/src/main/java/arile/toy/stock_service/domain/interest/InterestStock.java
@@ -10,7 +10,13 @@ import java.util.Objects;
 
 @Getter
 @ToString(callSuper = true)
-@Table(name = "interest_stocks")
+@Table(
+        name = "interest_stocks",
+        indexes = {
+                @Index(name = "idx_interest_stocks_interest_group_id", columnList = "interest_group_id"),
+                @Index(name = "idx_interest_stocks_stock_name", columnList = "stock_name")
+        }
+)
 @Entity
 public class InterestStock extends AuditingFields {
 

--- a/src/main/java/arile/toy/stock_service/domain/post/Dislike.java
+++ b/src/main/java/arile/toy/stock_service/domain/post/Dislike.java
@@ -9,7 +9,13 @@ import java.util.Objects;
 
 @Getter
 @ToString
-@Table(name = "dislikes")
+@Table(
+        name = "dislikes",
+        indexes = {
+                @Index(name = "idx_dislikes_unchangeable_id", columnList = "unchangeable_id"),
+                @Index(name = "idx_dislikes_post_id", columnList = "post_id")
+        }
+)
 @Entity
 public class Dislike {
 

--- a/src/main/java/arile/toy/stock_service/domain/post/Like.java
+++ b/src/main/java/arile/toy/stock_service/domain/post/Like.java
@@ -9,7 +9,13 @@ import java.util.Objects;
 
 @Getter
 @ToString
-@Table(name = "likes")
+@Table(
+        name = "likes",
+        indexes = {
+                @Index(name = "idx_likes_unchangeable_id", columnList = "unchangeable_id"),
+                @Index(name = "idx_likes_post_id", columnList = "post_id")
+        }
+)
 @Entity
 public class Like {
 

--- a/src/main/java/arile/toy/stock_service/domain/post/Post.java
+++ b/src/main/java/arile/toy/stock_service/domain/post/Post.java
@@ -12,7 +12,13 @@ import java.util.Objects;
 
 @Getter
 @ToString
-@Table(name = "posts")
+@Table(
+        name = "posts",
+        indexes = {
+                @Index(name = "idx_posts_unchangeable_id", columnList = "unchangeable_id"),
+                @Index(name = "idx_posts_stock_name", columnList = "stock_name")
+        }
+)
 @Entity
 public class Post {
 

--- a/src/main/java/arile/toy/stock_service/domain/post/Reply.java
+++ b/src/main/java/arile/toy/stock_service/domain/post/Reply.java
@@ -12,7 +12,13 @@ import java.util.Objects;
 
 @Getter
 @ToString
-@Table(name = "replies")
+@Table(
+        name = "replies",
+        indexes = {
+                @Index(name = "idx_replies_unchangeable_id", columnList = "unchangeable_id"),
+                @Index(name = "idx_replies_post_id", columnList = "post_id")
+        }
+)
 @Entity
 public class Reply {
 

--- a/src/main/java/arile/toy/stock_service/repository/StaticStockInfoRepository.java
+++ b/src/main/java/arile/toy/stock_service/repository/StaticStockInfoRepository.java
@@ -14,6 +14,7 @@ public interface StaticStockInfoRepository extends JpaRepository<StaticStockInfo
     @NonNull
     @Cacheable(value = "stockNames")
     List<StaticStockInfo> findAll();
+
     Optional<StaticStockInfo> findByStockName(String stockName);
 
 }

--- a/src/main/java/arile/toy/stock_service/service/StaticStockInfoService.java
+++ b/src/main/java/arile/toy/stock_service/service/StaticStockInfoService.java
@@ -18,7 +18,6 @@ public class StaticStockInfoService {
 
         return staticStockInfoRepository.findByStockName(stockName)
                 .map(StaticStockInfo::getShortCode)
-                // Optional
                 .orElseThrow(() -> new StaticStockInfoNotFoundException(stockName));
     }
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -45,7 +45,9 @@ CREATE TABLE posts (
         FOREIGN KEY (stock_name)
         REFERENCES static_stock_information(stock_name)
         ON DELETE CASCADE
-        ON UPDATE CASCADE
+        ON UPDATE CASCADE,
+    INDEX idx_posts_unchangeable_id (unchangeable_id),
+    INDEX idx_posts_stock_name (stock_name)
 );
 
 CREATE TABLE interest_groups (
@@ -60,7 +62,8 @@ CREATE TABLE interest_groups (
         FOREIGN KEY (unchangeable_id)
         REFERENCES github_user_information(unchangeable_id)
         ON DELETE CASCADE
-        ON UPDATE CASCADE
+        ON UPDATE CASCADE,
+    INDEX idx_interest_groups_unchangeable_id (unchangeable_id)
 );
 
 CREATE TABLE chatrooms (
@@ -79,9 +82,10 @@ CREATE TABLE chatrooms (
         FOREIGN KEY (stock_name)
         REFERENCES static_stock_information(stock_name)
         ON DELETE CASCADE
-        ON UPDATE CASCADE
+        ON UPDATE CASCADE,
+    INDEX idx_chatrooms_unchangeable_id (unchangeable_id),
+    INDEX idx_chatrooms_stock_name (stock_name)
 );
-
 
 CREATE TABLE replies (
     reply_id BIGINT PRIMARY KEY AUTO_INCREMENT,
@@ -99,7 +103,9 @@ CREATE TABLE replies (
         FOREIGN KEY (unchangeable_id)
         REFERENCES github_user_information(unchangeable_id)
         ON DELETE CASCADE
-        ON UPDATE CASCADE
+        ON UPDATE CASCADE,
+    INDEX idx_replies_post_id (post_id),
+    INDEX idx_replies_unchangeable_id (unchangeable_id)
 );
 
 CREATE TABLE likes (
@@ -115,7 +121,9 @@ CREATE TABLE likes (
         FOREIGN KEY (post_id)
         REFERENCES posts(post_id)
         ON DELETE CASCADE
-        ON UPDATE CASCADE
+        ON UPDATE CASCADE,
+    INDEX idx_likes_unchangeable_id (unchangeable_id),
+    INDEX idx_likes_post_id (post_id)
 );
 
 CREATE TABLE dislikes (
@@ -131,7 +139,9 @@ CREATE TABLE dislikes (
         FOREIGN KEY (post_id)
         REFERENCES posts(post_id)
         ON DELETE CASCADE
-        ON UPDATE CASCADE
+        ON UPDATE CASCADE,
+    INDEX idx_dislikes_unchangeable_id (unchangeable_id),
+    INDEX idx_dislikes_post_id (post_id)
 );
 
 CREATE TABLE interest_stocks (
@@ -156,7 +166,9 @@ CREATE TABLE interest_stocks (
         FOREIGN KEY (stock_name)
         REFERENCES static_stock_information(stock_name)
         ON DELETE CASCADE
-        ON UPDATE CASCADE
+        ON UPDATE CASCADE,
+    INDEX idx_interest_stocks_interest_group_id (interest_group_id),
+    INDEX idx_interest_stocks_stock_name (stock_name)
 );
 
 CREATE TABLE github_user_chatroom_mappings (
@@ -173,7 +185,9 @@ CREATE TABLE github_user_chatroom_mappings (
         FOREIGN KEY (unchangeable_id)
         REFERENCES github_user_information(unchangeable_id)
         ON DELETE CASCADE
-        ON UPDATE CASCADE
+        ON UPDATE CASCADE,
+    INDEX idx_github_user_chatroom_mappings_chatroom_id (chatroom_id),
+    INDEX idx_github_user_chatroom_mappings_unchangeable_id (unchangeable_id)
 );
 
 CREATE TABLE messages (
@@ -192,5 +206,7 @@ CREATE TABLE messages (
         FOREIGN KEY (chatroom_id)
         REFERENCES chatrooms(chatroom_id)
         ON DELETE CASCADE
-        ON UPDATE CASCADE
+        ON UPDATE CASCADE,
+    INDEX idx_messages_chatroom_id (chatroom_id),
+    INDEX idx_messages_unchangeable_id (unchangeable_id)
 );

--- a/src/main/resources/templates/my-groups.html
+++ b/src/main/resources/templates/my-groups.html
@@ -140,7 +140,9 @@
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300 text-center" th:text="${#temporals.format(interestGroup.createdAt, 'yyyy-MM-dd HH:mm')}">-</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300 text-center" th:text="${#temporals.format(interestGroup.modifiedAt, 'yyyy-MM-dd HH:mm')}">-</td>
                     <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium text-center">
-                        <form th:action="@{/interest-group/my-groups/{groupName}(groupName=${interestGroup.groupName})}" method="post" class="inline">
+                        <form th:action="@{/interest-group/my-groups/{groupName}(groupName=${interestGroup.groupName})}"
+                              method="post" class="inline"
+                              onsubmit="return confirmDelete('${interestGroup.groupName}')">
                             <button type="submit" class="text-red-600 dark:text-red-400">
                                 <i class="fas fa-trash-alt"></i>
                             </button>
@@ -190,6 +192,11 @@
         setTimeout(() => loadingScreen.remove(), 500);
       }
     });
+</script>
+<script>
+    function confirmDelete(groupName) {
+        return confirm(`정말 관심그룹을 삭제하시겠습니까?`);
+    }
 </script>
 </body>
 </html>


### PR DESCRIPTION
자식 테이블에서 부모 테이블의 값으로 조회하거나 삭제/업데이트 시 참조 무결성을 검사할 때,
index가 없으면 테이블 전체를 스캔(scan) 해야 해서 성능이 느려짐.
따라서 index를 추가함.
